### PR TITLE
Updated status code step definition to not conflict with drupal extension.

### DIFF
--- a/features/send_HTML_form_request.feature
+++ b/features/send_HTML_form_request.feature
@@ -9,7 +9,7 @@ Feature: Test request to API sent like a HTML form
       | field  | username       | pablo |
       | field  | password       | money |
       | field  | terms_accepted | 1     |
-    Then the response status code should be 200
+    Then the rest response status code should be 200
     And the response should be in JSON
     And the JSON node "content_type_header_value" should contain "application/x-www-form-urlencoded"
     And the JSON node "post_fields_count" should be equal to "3"
@@ -25,7 +25,7 @@ Feature: Test request to API sent like a HTML form
       | field  | terms_accepted | 1                                            |
       | file   | test-img       | features/bootstrap/fixtures/test-img.jpg     |
       | file   | json-schema    | features/bootstrap/fixtures/json-schema.json |
-    Then the response status code should be 200
+    Then the rest response status code should be 200
     And the response should be in JSON
     And the JSON node "content_type_header_value" should contain "multipart/form-data"
     And the JSON node "post_fields_count" should be equal to "3"

--- a/features/send_request.feature
+++ b/features/send_request.feature
@@ -5,11 +5,11 @@ Feature: Test send API request
 
     Scenario: Sending GET request to non existing ressource should lead to 404
         When I send a GET request to "simpson.json"
-        Then the response status code should be 404
+        Then the rest response status code should be 404
 
     Scenario: Sending GET request to existing ressource should lead to 200
         When I send a GET request to "echo"
-        Then the response status code should be 200
+        Then the rest response status code should be 200
 
     Scenario: Sending POST request with body
         Given I add "content-type" header equal to "application/json"
@@ -29,7 +29,7 @@ Feature: Test send API request
         Given I add "header" header equal to "value"
         And I add "header" header equal to "value2"
         When I send a POST request to "echo"
-        Then the response status code should be 200
+        Then the rest response status code should be 200
         And the JSON node "headers.header" should have 1 element
         And the JSON node "headers.header[0]" should be equal to "value, value2"
 
@@ -37,7 +37,6 @@ Feature: Test send API request
         Given I set "header" header equal to "value"
         And I set "header" header equal to "value2"
         When I send a POST request to "echo"
-        Then the response status code should be 200
+        Then the rest response status code should be 200
         And the JSON node "headers.header" should have 1 element
         And the JSON node "headers.header[0]" should be equal to "value2"
-        

--- a/src/RestApiContext.php
+++ b/src/RestApiContext.php
@@ -68,7 +68,7 @@ class RestApiContext implements Context, SnippetAcceptingContext
     /**
      * @param string $code status code
      *
-     * @Then /^(?:the )?response status code should be (\d+)$/
+     * @Then /^(?:the )rest ?response status code should be (\d+)$/
      */
     public function theResponseCodeShouldBe($code)
     {


### PR DESCRIPTION
`Then the response status code should be` step definitions breaks tests for Drupal site using behat drupal extensions because both extensions define this step definition.

This PR resolves the issue by changing this step definition to include the word `rest`.

I realise that chances to have this PR merged are low, but at least this can serve as a reference for other developers.