### PR TITLE
Json path expression should have a result does not check for empty result list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_script:
         if [ ! $(php -m | grep -ci xdebug) -eq 0 ] ; then
             phpenv config-rm xdebug.ini
         fi
-    - composer global require hirak/prestissimo
     - composer update $COMPOSER_PREFER
     - |
         # We force latest atoum on php >=7

--- a/features/json_inspection.feature
+++ b/features/json_inspection.feature
@@ -143,6 +143,7 @@ Feature: Test json inspection payload
 
     Scenario: JSON path expression equal to inline json
         Then the JSON path expression "foos[?foo == 'bar'].bar" should be equal to json '["bar"]'
+        Then the JSON path expression "foos[?foo == 'nobar'].bar" should be equal to json '[]'
 
     Scenario: JSON path expression equal to given json
         Then the JSON path expression "foos[?foo == 'bar'].bar" should be equal to:

--- a/features/json_inspection.feature
+++ b/features/json_inspection.feature
@@ -1,4 +1,4 @@
-@json_inspection @wip
+@json_inspection
 Feature: Test json inspection payload
     In order to verify my json response
     As a developper

--- a/features/json_inspection.feature
+++ b/features/json_inspection.feature
@@ -1,4 +1,4 @@
-@json_inspection
+@json_inspection @wip
 Feature: Test json inspection payload
     In order to verify my json response
     As a developper
@@ -155,3 +155,4 @@ Feature: Test json inspection payload
 
     Scenario: JSON path expression have result
         Then the JSON path expression "fooo.bar" should not have result
+        Then the JSON path expression "foos[?foo == 'nobar'].bar" should not have result

--- a/src/Json/JsonContext.php
+++ b/src/Json/JsonContext.php
@@ -219,6 +219,7 @@ class JsonContext implements Context, SnippetAcceptingContext
     {
         $json = $this->jsonInspector->searchJsonPath($pathExpression);
         $this->asserter->variable($json)->isNotNull();
+        $this->asserter->variable($json)->isNotEqualTo([]);
     }
 
     /**
@@ -227,7 +228,11 @@ class JsonContext implements Context, SnippetAcceptingContext
     public function theJsonPathExpressionShouldNotHaveResult($pathExpression)
     {
         $json = $this->jsonInspector->searchJsonPath($pathExpression);
-        $this->asserter->variable($json)->isNull();
+        if (is_array($json) && empty($json)) {
+          $this->asserter->variable($json)->isEqualTo([]);
+        } else {
+          $this->asserter->variable($json)->isNull();
+        }
     }
 
     private function evaluateJsonNodeValue($jsonNode)


### PR DESCRIPTION
When evaluating an expression like `foos[?foo == 'nobar'].bar` on the below example JSON, the returned value is `[]` rather than `NULL`. It returns an empty result list rather than a null value.

The library `JsonContext::theJsonPathExpressionShouldHaveResult` and `JsonContext::theJsonPathExpressionShouldNotHaveResult()` only check for NULL value when asserting whether there is a result passing the above expression.

This PR changes the evaluation to also check for an empty array and / or null value.


Example JSON:
`        {
            "foo": "bar",
            "footrue": true,
            "foofalse": false,
            "foonull": null,
            "fooint": 1337,
            "foos": [
                {"foo": "bar", "bar": "bar"},
                {"foo2": "bar2"}
            ],
            "fooo": {
                "foo": "bar"
            },
            "fooarray": [
                "bar1",
                "bar2"
            ]
        }`