### PR TITLE
Allow to use symfony/property-access > 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "php": ">=7.2",
         "behat/behat": "^3.8",
         "atoum/atoum": "^4",
-        "symfony/property-access": "~4.0",
         "justinrainbow/json-schema": ">=5.2.10 <6.0",
         "psr/http-message": "^1.0",
         "php-http/discovery": "^1.13",
@@ -32,7 +31,8 @@
         "tolerance/tolerance": "^0.4.2",
         "mtdowling/jmespath.php": "^2.3",
         "symfony/config": "^4.4.12 | ~5.0",
-        "symfony/dependency-injection": "^4.4.12 | ~5.0"
+        "symfony/dependency-injection": "^4.4.12 | ~5.0",
+        "symfony/property-access": "^4.4.12 | ~5.0"
     },
     "require-dev": {
         "silex/silex": "~2.0",


### PR DESCRIPTION
#### Pain Point

In order to fix

```
Problem 1
    - Root composer.json requires ubirak/rest-api-behat-extension ^8.0 -> satisfiable by ubirak/rest-api-behat-extension[8.0.0].
    - ubirak/rest-api-behat-extension 8.0.0 requires symfony/property-access ~4.0 -> found symfony/property-access[v4.0.0-BETA1, ..., v4.4.20] but it conflicts with your root composer.json require (5.2.*).
```

#### TODO 

- [x] Take the same range as `symfony/config` and `symfony/dependency-injection`. Unless there was a reason ?
- [x] Reorder so we no more forget it


Keep up the good work