### PR TITLE
Fix Deprecated: Function ReflectionType::__toString()

### DIFF
--- a/src/Json/JsonInspectorResolver.php
+++ b/src/Json/JsonInspectorResolver.php
@@ -22,7 +22,7 @@ class JsonInspectorResolver implements ArgumentResolver
 
         $parameters = $constructor->getParameters();
         foreach ($parameters as $parameter) {
-            if (null !== $parameter->getType() && ((string)$parameter->getType()) === 'Ubirak\RestApiBehatExtension\Json\JsonInspector') {
+            if (null !== $parameter->getType() && ($parameter->getType()->getName()) === 'Ubirak\RestApiBehatExtension\Json\JsonInspector') {
                 $arguments[$parameter->name] = $this->jsonInspector;
             }
         }

--- a/src/Rest/RestApiBrowserResolver.php
+++ b/src/Rest/RestApiBrowserResolver.php
@@ -22,7 +22,7 @@ class RestApiBrowserResolver implements ArgumentResolver
 
         $parameters = $constructor->getParameters();
         foreach ($parameters as $parameter) {
-            if (null !== $parameter->getType() && ((string)$parameter->getType()) === 'Ubirak\RestApiBehatExtension\Rest\RestApiBrowser') {
+            if (null !== $parameter->getType() && ($parameter->getType()->getName()) === 'Ubirak\RestApiBehatExtension\Rest\RestApiBrowser') {
                 $arguments[$parameter->name] = $this->restApiBrowser;
             }
         }


### PR DESCRIPTION
We can no more directly cast via `(string)$parameter->getType()`