### PR TITLE
Introduce PHP 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
     - 7.3
     - 7.4
     - 8.0
+    - 8.1
     - nightly
 env:
     matrix:

--- a/src/Html/Form.php
+++ b/src/Html/Form.php
@@ -2,18 +2,18 @@
 
 namespace Ubirak\RestApiBehatExtension\Html;
 
-class Form 
+class Form
 {
     private $body = [];
-    
+
     private $contentTypeHeaderValue = '';
 
-    public function __construct(array $body) 
+    public function __construct(array $body)
     {
         $this->body = $body;
     }
 
-    public function getBody() 
+    public function getBody()
     {
         if ($this->bodyHasFileObject()) {
             return $this->getMultipartStreamBody();
@@ -23,28 +23,28 @@ class Form
     }
 
     /**
-     * 
+     *
      * @return string
      */
-    public function getContentTypeHeaderValue() 
+    public function getContentTypeHeaderValue()
     {
         return $this->contentTypeHeaderValue;
     }
 
     /**
-     * 
+     *
      * @param string $value
      */
-    private function setContentTypeHeaderValue($value) 
+    private function setContentTypeHeaderValue($value)
     {
         $this->contentTypeHeaderValue = $value;
     }
 
     /**
-     * 
+     *
      * @return boolean
      */
-    private function bodyHasFileObject() 
+    private function bodyHasFileObject()
     {
         foreach ($this->body as $element) {
             if ($element['object'] == 'file') {
@@ -56,10 +56,10 @@ class Form
     }
 
     /**
-     * 
+     *
      * @return \GuzzleHttp\Psr7\MultipartStream
      */
-    private function getMultipartStreamBody() 
+    private function getMultipartStreamBody()
     {
         $multiparts = array_map(
                 function ($element) {
@@ -80,10 +80,10 @@ class Form
     }
 
     /**
-     * 
+     *
      * @return string
      */
-    private function getNameValuePairBody() 
+    private function getNameValuePairBody()
     {
         $body = [];
         foreach ($this->body as $element) {
@@ -92,7 +92,7 @@ class Form
 
         $this->setContentTypeHeaderValue('application/x-www-form-urlencoded');
 
-        return http_build_query($body, null, '&');       
+        return http_build_query($body);
     }
 
 }

--- a/src/Json/JsonContext.php
+++ b/src/Json/JsonContext.php
@@ -19,7 +19,11 @@ class JsonContext implements Context, SnippetAcceptingContext
     {
         $this->jsonInspector = $jsonInspector;
         $this->asserter = new asserter();
-        $this->jsonSchemaBaseUrl = rtrim((string) $jsonSchemaBaseUrl, '/');
+
+        if (null !== $jsonSchemaBaseUrl) {
+            $jsonSchemaBaseUrl = rtrim($jsonSchemaBaseUrl, '/');
+        }
+        $this->jsonSchemaBaseUrl = $jsonSchemaBaseUrl;
     }
 
     /**


### PR DESCRIPTION
> rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in /data/vendor/ubirak/rest-api-behat-extension/src/Json/JsonContext.php line 22 